### PR TITLE
Fix InvalidProgramException

### DIFF
--- a/profiling/mathexp/App.cs
+++ b/profiling/mathexp/App.cs
@@ -44,29 +44,9 @@ class App {
 		spec.AstRule("Number:Exp->value");
 		spec.AstRule("Const:Exp->name");
 		spec.CompileAstSpecifications("Root");
-
-		spec.SpecifyAttribute("Eval", "Root", "*", true, (n) =>
-			n.GetExp().Eval());
-
-		spec.SpecifyAttribute("Eval", "AddExp", "*", true, (n) =>
-			n.GetA().Eval() + n.GetB().Eval());
-
-		spec.SpecifyAttribute("Eval", "MulExp", "*", true, (n) =>
-			n.GetA().Eval() * n.GetB().Eval());
-
-		spec.SpecifyAttribute("Eval", "Number", "*", true, (n) =>
-			n.GetValue());
-
-		spec.SpecifyAttribute("Eval", "Const", "*", true, (n) =>
-			n.Lookup(n.GetName()).GetValue());
-
-		spec.SpecifyAttribute("Lookup", "Root", "*", true,
-							  (Racr.AstNode n, string name) =>
-			(Racr.AstNode) n.GetDefs().FindChild((i, d) =>
-				((Racr.AstNode) d).GetName() == name));
-
+		
+		spec.RegisterAgRules(typeof(App));
 		spec.CompileAgSpecifications();
-
 
 		var defs = spec.CreateAstList(
 				spec.CreateAst("Def", "a", 0.0),
@@ -112,6 +92,36 @@ class App {
 
 		watch.Stop();
 		Console.WriteLine("Time: {0}", watch.ElapsedMilliseconds * 0.001);
+	}
+
+	[Racr.AgRule("Lookup", "Root", Cached = true, Context = "*")]
+	private static Racr.AstNode EvalConst(Racr.AstNode node, string name) {
+		return (Racr.AstNode)node.GetDefs().FindChild((i, d) => ((Racr.AstNode)d).GetName() == name);
+	}
+
+	[Racr.AgRule("Eval", "Const", Cached = true, Context = "*")]
+	private static double EvalConst(Racr.AstNode node) {
+		return node.Lookup(node.GetName()).GetValue();
+	}
+
+	[Racr.AgRule("Eval", "Number", Cached = true, Context = "*")]
+	private static double EvalNumber(Racr.AstNode node) {
+		return node.GetValue();
+	}
+ 
+	[Racr.AgRule("Eval", "AddExp", Cached = true, Context = "*")]
+	private static double EvalAddExp(Racr.AstNode node) {
+		return node.GetA().Eval() + node.GetB().Eval();
+	}
+
+	[Racr.AgRule("Eval", "MulExp", Cached = true, Context = "*")]
+	private static double EvalMulExp(Racr.AstNode node) {
+		return node.GetA().Eval() * node.GetB().Eval();
+	}
+	
+	[Racr.AgRule("Eval", "Root", Cached = true, Context = "*")]
+	private static double EvalRoot(Racr.AstNode node) {
+		return node.GetExp().Eval();
 	}
 }
 


### PR DESCRIPTION
Calling `Specification.SpecifyAttribute(...)` throws in an InvalidProgramException. It seems that `Racr.Specification.WrapToCallable(MethodInfo method)` emits invalid MSIL code. Using Methods with `Racr.AgRuleAttribute` instead fixes the symptom.

**Exception message:**

> An unhandled exception of type 'System.InvalidProgramException' occurred in mscorlib.dll
> Additional information: Common Language Runtime detected an invalid program.

**Stacktrace:**

>    at System.Runtime.CompilerServices.RuntimeHelpers._CompileMethod(IRuntimeMethodInfo method)
>    at System.Reflection.Emit.DynamicMethod.CreateDelegate(Type delegateType)
>    at Racr.Specification.WrapToCallable(MethodInfo method)
>    at Racr.Specification.SpecifyAttribute(String attName, String nonTerminal, String contextName, Boolean cached, Delegate equation)
>    at Racr.Specification.SpecifyAttribute[R](String attName, String nonTerminal, String contextName, Boolean cached, Func`2 equation)
>    at App.Main() in C:\Sources\racr\profiling\mathexp\App.cs:line 48
>    at System.AppDomain._nExecuteAssembly(RuntimeAssembly assembly, String[] args)
>    at System.AppDomain.ExecuteAssembly(String assemblyFile, Evidence assemblySecurity, String[] args)
>    at Microsoft.VisualStudio.HostingProcess.HostProc.RunUsersAssembly()
>    at System.Threading.ThreadHelper.ThreadStart_Context(Object state)
>   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
>    at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
>    at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state)
>    at System.Threading.ThreadHelper.ThreadStart()

**Environment:**
- Win 8.1 x64
- VS 2015
- Target fx: Net 4.0 as well as Net 4.5.0
